### PR TITLE
Add except to AbstractFieldRuleSet

### DIFF
--- a/tests/FieldRuleSetTest.php
+++ b/tests/FieldRuleSetTest.php
@@ -44,6 +44,18 @@ class FieldRuleSetTest extends TestCase
         $this->assertEquals($this->getError($errorKey, $attribute, $extra), $rule->message());
     }
 
+    /**
+     * @test
+     */
+    public function it_can_use_a_rule_set_except_certain_rules()
+    {
+        $attribute = 'email_address';
+
+        $rule = (new NewEmailRuleSet)->except('required', 'email');
+
+        $this->assertTrue($rule->passes($attribute, null));
+    }
+
     public function providesInvalidValues()
     {
         return [


### PR DESCRIPTION
Adds the possibility to except certain rules from the rule set. Useful if you have a rule set that should be reused without one or more rules.